### PR TITLE
Several fixes

### DIFF
--- a/IchigoJam.md
+++ b/IchigoJam.md
@@ -7,24 +7,27 @@ The boards are very popular, even with adaults, as the IchigoJam BASIC is almost
 
 For adults the "next step up" in hardware is the RPi, as most of the IchigoJam daughter boards can also be connected to the user SPI pins on the RPi. They eventually created [IchicoJam BASIC for RPi](https://ichigojam.github.io/RPi/) _and_ PC.
 
-#### Main IchogoJam Website
-https://ichigojam.net/
-
-#### Main IchigoJam Community Pages
-https://15jamrecipe.jimdo.com/
-
-#### IchicoJam BASIC (english)
+#### IchigoJam (official website)
 https://ichigojam.net/index-en.html
 
-#### IchicoJam BASIC for RPi
+#### IchigoJam (Japanese official)
+https://ichigojam.net/
+
+#### PCN Programmig club network
+https://pcn.club/index.en.html
+
+#### IchigoJam Recipe (Japanese)
+https://15jamrecipe.jimdo.com/
+
+#### IchicoJam BASIC RPi (use Raspberry Pi)
 https://ichigojam.github.io/RPi/
 
 #### IchigoJam BASIC English Quick Reference
 https://ichigojam.net/IchigoJam-en.html
 
-#### How to use MixJuice in IchigoJam BASIC
+#### How to use MixJuice in IchigoJam BASIC and IchigoLatte (Japanese)
 https://15jamrecipe.jimdo.com/mixjuice/%E6%BA%96%E5%82%99-%E4%BD%BF%E3%81%84%E6%96%B9/
 
-#### How to use with IchigoLatte
+#### MixJuice Contents (Japanese)
 https://15jamrecipe.jimdo.com/mixjuice/%E3%82%B3%E3%83%B3%E3%83%86%E3%83%B3%E3%83%84/
 


### PR DESCRIPTION
I fixed some of it:
- Some "IchigoJam" are incorrect.
- PCN was added. This site is one of official and important.
- "イチゴジャム レシピ"(IchigoJam Recipe) is NOT an official website.
- The link of IchigoJam Recipe/MixJuice was clearly wrong.
- Japanese website added "(Japanese)"